### PR TITLE
fix(client): attach security token only when present

### DIFF
--- a/mns/mns_client.py
+++ b/mns/mns_client.py
@@ -744,7 +744,7 @@ class MNSClient(object):
                                          (pkg_info.version, platform.system(), platform.release(), platform.machine(), platform.python_version())
         credential = self.credentials_provider.get_credentials()
         req_inter.header["Authorization"] = self.get_signature(req_inter.method, req_inter.header, req_inter.uri, credential)
-        if credential.get_security_token() != "":
+        if credential.get_security_token():
             req_inter.header["security-token"] = credential.get_security_token()
 
     def get_signature(self, method, headers, resource, credential):


### PR DESCRIPTION
fix: #8

Security token could be None when using CredentialProviders from [alibabacloud-credentials](https://github.com/aliyun/credentials-python), such as the [StaticAKCredentialsProvider](https://github.com/aliyun/credentials-python/blob/master/alibabacloud_credentials/provider/static_ak.py) or [EnvironmentVariableCredentialsProvider](https://github.com/aliyun/credentials-python/blob/master/alibabacloud_credentials/provider/env.py) with RAM user ak/sk. Update the check to cover both empty string and None.